### PR TITLE
feat: allow multiple taxids to be specified with -t

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     #[arg(short = 'r', long = "report", value_parser(check_input_exists), required_if_eq_any([("parents", "true"), ("children", "true")]))]
     pub report: Option<PathBuf>,
     // Taxid to extract reads for
-    #[arg(short = 't', long = "taxid", required = true)]
+    #[arg(short = 't', long = "taxid", required = true, num_args(1..))]
     pub taxid: Vec<i32>,
     // Compression type
     #[arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
     pub report: Option<PathBuf>,
     // Taxid to extract reads for
     #[arg(short = 't', long = "taxid", required = true)]
-    pub taxid: i32,
+    pub taxid: Vec<i32>,
     // Compression type
     #[arg(
         short = 'O',


### PR DESCRIPTION
This adds functionality for multiple taxids to be extracted using `-t`

Functionality is preserved for `--children` and `--parents` so if multiple taxids are specified - the parents or children for each will be extracted.

Specify more than one taxid by doing `-t` multiple times